### PR TITLE
Mark windows as unsupported for trycompile

### DIFF
--- a/trycompile/src/lib.rs
+++ b/trycompile/src/lib.rs
@@ -80,7 +80,7 @@ impl TestCases {
     pub fn into_runner(self) -> Result<impl Runner> {
         let cargo_file_dir = std::env::current_dir()?;
 
-        Ok(OofSeqRunner {
+        Ok(SeqRunner {
             cargo_file_dir,
             check_compile: self,
         })
@@ -159,12 +159,20 @@ pub trait Runner {
     fn run_test_cases(&self) -> Result<()>;
 }
 
-struct OofSeqRunner {
+struct SeqRunner {
     cargo_file_dir: PathBuf,
     check_compile: TestCases,
 }
 
-impl Runner for OofSeqRunner {
+impl Runner for SeqRunner {
+    #[cfg(windows)]
+    fn run_test_cases(&self) -> Result<()> {
+        eprintln!("[warn(trycompile)] Windows is currently not supported by this prototype... No actual tests will be run, but the runner will succeed...");
+
+        Ok(())
+    }
+
+    #[cfg(not(windows))]
     fn run_test_cases(&self) -> Result<()> {
         // this should probably be rustc, but to make it easy for ourselves, we use cargo instead,
         // as this is a prototype 🥰

--- a/trycompile/src/lib.rs
+++ b/trycompile/src/lib.rs
@@ -4,12 +4,14 @@
 //!
 //! Not production ready; in a messy state; prototype only
 
+#![cfg_attr(windows, allow(unused))]
+
 use eyre::{eyre, Result};
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
-use tempfile::{tempdir, TempDir};
+use tempfile::TempDir;
 
 pub type TestFilePath = std::path::PathBuf;
 
@@ -174,6 +176,8 @@ impl Runner for SeqRunner {
 
     #[cfg(not(windows))]
     fn run_test_cases(&self) -> Result<()> {
+        use tempfile::tempdir;
+
         // this should probably be rustc, but to make it easy for ourselves, we use cargo instead,
         // as this is a prototype 🥰
 


### PR DESCRIPTION
If I will develop (and likely even if not) trycompile further, I will look into adding windows support. For now however I marked it as unsupported. Tests run on windows will always succeed, but no actual test case will run. This ensures CI succeeds when testing on the windows platform (while a unix platform is still be able to fail, since there the tests will be run regularly). The reason for adding this is that sif_macro also uses this test runner now as a complementary runner to trybuild, but the CI fails on windows. I would have added a feature in the Cargo.toml, and let the test table for trycompile have that required-feature, but this isn't possible since Cargo doesn't support optional features for dev-dependencies.